### PR TITLE
Make App.framework static

### DIFF
--- a/firebase-crash-sample.xcodeproj/project.pbxproj
+++ b/firebase-crash-sample.xcodeproj/project.pbxproj
@@ -1001,6 +1001,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MACH_O_TYPE = staticlib;
 				PRODUCT_BUNDLE_IDENTIFIER = "dev.mironal.firebase-crash-sample.App";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -1029,6 +1030,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MACH_O_TYPE = staticlib;
 				PRODUCT_BUNDLE_IDENTIFIER = "dev.mironal.firebase-crash-sample.App";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
According to the [guide](https://github.com/firebase/firebase-ios-sdk/blob/master/docs/firebase_in_libraries.md#using-firebase-sdks-from-dynamic-framework) Firebase cannot be safely used from both a dynamic framework and an app dependent on the dynamic framework. Converting the framework to static is one of the solutions to the issue.